### PR TITLE
Better sanitize userspace input to improve driver stability

### DIFF
--- a/Module/ca8210.c
+++ b/Module/ca8210.c
@@ -2765,6 +2765,9 @@ static ssize_t ca8210_test_int_user_write(
 	struct ca8210_priv *priv = filp->private_data;
 	uint8_t command[CA8210_SPI_BUF_SIZE];
 
+	if (len > CA8210_SPI_BUF_SIZE)
+		return 0;
+
 	if (copy_from_user(command, in_buf, len))
 		return 0;
 
@@ -2818,7 +2821,7 @@ static ssize_t ca8210_test_int_user_read(
 		return 0;
 	}
 	cmdlen = fifo_buffer[1];
-	memcpy(buf, fifo_buffer, cmdlen + 2);
+	copy_to_user(buf, fifo_buffer, cmdlen + 2);
 
 	kfree(fifo_buffer);
 


### PR DESCRIPTION
*Prevent a buffer overflow vulnerability in ca8210_test_int_user_write by checking the validity of len.
*Replace memcpy with copy_to_user in ca8210_test_int_user_read for address validity checks
