### PR TITLE
Ckt 435 spi driver fails at 30m range

### DIFF
--- a/Module/ca8210.c
+++ b/Module/ca8210.c
@@ -687,8 +687,7 @@ static void ca8210_reset_send(struct spi_device *spi, int ms)
 }
 
 /**
- * ca8210_MLME_reset_worker() - Starts the spi read process after having the work
- *                       handed off by the interrupt handler
+ * ca8210_MLME_reset_worker() - Resets the MLME, Called when the MAC OVERFLOW condition happens.
  * @work:  Pointer to work being executed
  */
 static void ca8210_MLME_reset_worker(struct work_struct *work)

--- a/Module/ca8210.c
+++ b/Module/ca8210.c
@@ -333,7 +333,7 @@ struct ca8210_test {
  * @hw_registered:          true if hw has been registered with ieee802154
  * @lock:                   spinlock protecting the private data area
  * @async_tx_workqueue:     workqueue for asynchronous transmission
- * @rx_workqueue:           workqueue for receive processing
+ * @MLME_workqueue:           workqueue for triggering MLME Reset
  * @irq_workqueue:          workqueue for irq processing
  * @async_tx_work:          work object for a single asynchronous transmission
  * @async_tx_timeout_work:  delayed work object for a single asynchronous
@@ -364,7 +364,7 @@ struct ca8210_priv {
 	struct ieee802154_hw *hw;
 	bool hw_registered;
 	spinlock_t lock;
-	struct workqueue_struct *async_tx_workqueue, *rx_workqueue;
+	struct workqueue_struct *async_tx_workqueue, *MLME_workqueue;
 	struct workqueue_struct *irq_workqueue;
 	struct work_struct async_tx_work;
 	struct delayed_work async_tx_timeout_work;
@@ -687,24 +687,38 @@ static void ca8210_reset_send(struct spi_device *spi, int ms)
 }
 
 /**
- * ca8210_rx_done() - Calls various message dispatches responding to a received
- *                    command
+ * ca8210_MLME_reset_worker() - Starts the spi read process after having the work
+ *                       handed off by the interrupt handler
  * @work:  Pointer to work being executed
- *
- * Presents a received SAP command from the ca8210 to the Cascoda EVBME, test
- * interface and network driver.
  */
-static void ca8210_rx_done(struct work_struct *work)
+static void ca8210_MLME_reset_worker(struct work_struct *work)
 {
 	struct work_priv_container *wpc = container_of(
 		work,
 		struct work_priv_container,
 		work
 	);
+
 	struct ca8210_priv *priv = wpc->priv;
+	mlme_reset_request_sync(0, priv->spi);
+	kfree(wpc);
+}
+
+/**
+ * ca8210_rx_done() - Calls various message dispatches responding to a received
+ *                    command
+ * @arg:  Pointer to the drivers private data structure
+ *
+ * Presents a received SAP command from the ca8210 to the Cascoda EVBME, test
+ * interface and network driver.
+ */
+static void ca8210_rx_done(struct ca8210_priv *priv)
+{
 	uint8_t buf[CA8210_SPI_BUF_SIZE];
 	uint8_t len;
 	unsigned long flags;
+	struct work_priv_container *mlme_reset_wq;
+
 
 	spin_lock_irqsave(&priv->lock, flags);
 
@@ -723,7 +737,7 @@ static void ca8210_rx_done(struct work_struct *work)
 
 	if (buf[0] & SPI_SYN) {
 		if (mutex_lock_interruptible(&priv->sync_command_mutex)) {
-			goto cleanup;
+			return;
 		}
 		if (priv->sync_command_pending) {
 			if (priv->sync_command_response == NULL) {
@@ -734,7 +748,7 @@ static void ca8210_rx_done(struct work_struct *work)
 					"Sync command provided no response " \
 					"buffer\n"
 				);
-				goto cleanup;
+				return;
 			}
 			memcpy(priv->sync_command_response, buf, len);
 			priv->sync_command_pending = false;
@@ -761,7 +775,11 @@ static void ca8210_rx_done(struct work_struct *work)
 			dev_info(
 				&priv->spi->dev,
 				"Resetting MAC...\n");
-			mlme_reset_request_sync(0, priv->spi);
+
+			mlme_reset_wq = kmalloc(sizeof(struct work_priv_container),GFP_KERNEL);
+			INIT_WORK(&mlme_reset_wq->work, ca8210_MLME_reset_worker);
+			mlme_reset_wq->priv = priv;
+			queue_work(priv->MLME_workqueue, &mlme_reset_wq->work);
 		}
 	} else if (buf[0] == SPI_HWME_WAKEUP_INDICATION) {
 		dev_notice(
@@ -824,8 +842,7 @@ static void ca8210_rx_done(struct work_struct *work)
 		spin_unlock_irqrestore(&priv->lock, flags);
 	}
 
-cleanup:
-	kfree(wpc);
+	return;
 }
 
 /**
@@ -939,14 +956,8 @@ static int ca8210_spi_read(struct spi_device *spi)
 		dev_dbg(&spi->dev, "%#03x\n", priv->cas_ctl.rx_final_buf[i]);
 	}
 
-	/* Offload rx processing to workqueue */
-	rx_wpc = kmalloc(
-		sizeof(struct work_priv_container),
-		GFP_KERNEL
-	);
-	INIT_WORK(&rx_wpc->work, ca8210_rx_done);
-	rx_wpc->priv = priv;
-	queue_work(priv->rx_workqueue, &rx_wpc->work);
+
+	ca8210_rx_done(priv);
 	return 0;
 
 error:
@@ -1113,13 +1124,7 @@ static int ca8210_spi_write(
 			priv->cas_ctl.tx_in_buf + 2,
 			priv->cas_ctl.rx_final_buf[1]
 		);
-		rx_wpc = kmalloc(
-			sizeof(struct work_priv_container),
-			GFP_KERNEL
-		);
-		INIT_WORK(&rx_wpc->work, ca8210_rx_done);
-		rx_wpc->priv = priv;
-		queue_work(priv->rx_workqueue, &rx_wpc->work);
+		ca8210_rx_done(priv);
 	}
 	return status;
 }
@@ -3173,17 +3178,12 @@ static int ca8210_dev_com_init(struct ca8210_priv *priv)
 	priv->cas_ctl.rx_transfer.speed_hz = 0; /* Use device setting */
 	priv->cas_ctl.rx_transfer.bits_per_word = 0; /* Use device setting */
 
-	priv->rx_workqueue = alloc_ordered_workqueue(
-		"ca8210 rx worker",
-		WQ_UNBOUND
-	);
-	if (priv->rx_workqueue == NULL) {
-		dev_crit(&priv->spi->dev, "alloc of rx_workqueue failed!\n");
+	priv->MLME_workqueue = alloc_ordered_workqueue("MLME work queue", WQ_UNBOUND);
+	if (priv->MLME_workqueue == NULL) {
+		dev_crit(&priv->spi->dev, "alloc of MLME_workqueue failed!\n");
 	}
-	priv->irq_workqueue = alloc_ordered_workqueue(
-		"ca8210 irq worker",
-		WQ_UNBOUND
-	);
+
+	priv->irq_workqueue = alloc_ordered_workqueue("ca8210 irq worker", WQ_UNBOUND);
 	if (priv->irq_workqueue == NULL) {
 		dev_crit(&priv->spi->dev, "alloc of irq_workqueue failed!\n");
 	}
@@ -3211,8 +3211,8 @@ error:
  */
 static void ca8210_dev_com_clear(struct ca8210_priv *priv)
 {
-	flush_workqueue(priv->rx_workqueue);
-	destroy_workqueue(priv->rx_workqueue);
+	flush_workqueue(priv->MLME_workqueue);
+	destroy_workqueue(priv->MLME_workqueue);
 	flush_workqueue(priv->irq_workqueue);
 	destroy_workqueue(priv->irq_workqueue);
 


### PR DESCRIPTION
The Driver was getting stuck when the MAC overflow condition or Data confirm timeout happened, removed on of the work queues in the receive path as work queues are inherently asynchronous, the interrupt will be disabled the entire time of the received packet processed but did not see any negative impact on throughput.
