### PR TITLE
Wake up the waiting poll thread after adding to the queue

### DIFF
--- a/Module/ca8210.c
+++ b/Module/ca8210.c
@@ -635,6 +635,7 @@ static int ca8210_test_int_driver_write(
 
 	fifo_buffer = kmalloc(len, GFP_KERNEL);
 	memcpy(fifo_buffer, buf, len);
+	wake_up_interruptible(priv->test.readq);
 	kfifo_in(&test->up_fifo, &fifo_buffer, 4);
 
 	return 0;

--- a/Module/ca8210.c
+++ b/Module/ca8210.c
@@ -636,7 +636,7 @@ static int ca8210_test_int_driver_write(
 	fifo_buffer = kmalloc(len, GFP_KERNEL);
 	memcpy(fifo_buffer, buf, len);
 	kfifo_in(&test->up_fifo, &fifo_buffer, 4);
-	wake_up_interruptible(priv->test.readq);
+	wake_up_interruptible(&priv->test.readq);
 
 	return 0;
 }

--- a/Module/ca8210.c
+++ b/Module/ca8210.c
@@ -635,8 +635,8 @@ static int ca8210_test_int_driver_write(
 
 	fifo_buffer = kmalloc(len, GFP_KERNEL);
 	memcpy(fifo_buffer, buf, len);
-	wake_up_interruptible(priv->test.readq);
 	kfifo_in(&test->up_fifo, &fifo_buffer, 4);
+	wake_up_interruptible(priv->test.readq);
 
 	return 0;
 }


### PR DESCRIPTION
Although the ca8210_test_int_poll function waits on the changing of a condition variable, it is not woken following changes to this. This pull request simply wakes the process after data is added to the fifo, to enable correct operation.