### PR TITLE
Restructure IRQ to send to a workqueue

### DIFF
--- a/Module/ca8210.c
+++ b/Module/ca8210.c
@@ -1084,7 +1084,7 @@ static irqreturn_t ca8210_interrupt_handler(int irq, void *dev_id)
 
 	dev_dbg(&priv->spi->dev, "irq: Interrupt occurred\n");
 
-	queue_work(priv->irq_workqueue, priv->irq_work->work);
+	queue_work(priv->irq_workqueue, &priv->irq_work->work);
 
 	return IRQ_HANDLED;
 }
@@ -1103,7 +1103,7 @@ static void ca8210_interrupt_queued (struct work_struct *work)
 		status = ca8210_spi_transfer(wpc->priv->spi, NULL, 0);
 		if (status && (status != -EBUSY)) {
 			dev_warn(
-				&priv->spi->dev,
+				&wpc->priv->spi->dev,
 				"spi read failed, returned %d\n",
 				status
 			);
@@ -2970,7 +2970,7 @@ static int ca8210_dev_com_init(struct ca8210_priv *priv)
 	}
 	priv->irq_work = kmalloc(sizeof(*priv->irq_work), GFP_KERNEL);
 	priv->irq_work->priv = priv;
-	INIT_WORK(priv->irq_work->work, &ca8210_interrupt_queued);
+	INIT_WORK(&priv->irq_work->work, &ca8210_interrupt_queued);
 
 	return 0;
 }

--- a/Module/ca8210.c
+++ b/Module/ca8210.c
@@ -867,7 +867,7 @@ static int ca8210_remove(struct spi_device *spi_device);
 
 static void ca8210_spi_transfer_retry_worker(struct work_struct *work){
 	struct work_data_container *wdc = container_of(
-			work,
+			to_delayed_work(work),
 			struct work_data_container,
 			work
 		);

--- a/Module/ca8210.c
+++ b/Module/ca8210.c
@@ -921,6 +921,8 @@ static void ca8210_spi_transfer_complete(void *context)
 			return;
 		}
 
+		//TODO: If too many retries, give up & enter error state
+
 		retry_work = kmalloc(sizeof(*retry_work), GFP_ATOMIC);
 		retry_work->priv = priv;
 		INIT_DELAYED_WORK(
@@ -933,7 +935,7 @@ static void ca8210_spi_transfer_complete(void *context)
 		queue_delayed_work(
 			priv->irq_workqueue,
 			&retry_work->work,
-			msecs_to_jiffies(priv->retries)
+			msecs_to_jiffies(priv->retries * 10)
 		);
 		dev_info(&priv->spi->dev, "queued spi write retry\n");
 		return;

--- a/Module/ca8210.c
+++ b/Module/ca8210.c
@@ -888,6 +888,22 @@ static void ca8210_spi_transfer_complete(void *context)
 	struct work_data_container *retry_work;
 	bool duplex_rx = false;
 
+	dev_dbg(&priv->spi->dev, "spi transfer complete.\n");
+	dev_dbg(&priv->spi->dev, "spi transfer out: \n");
+	print_hex_dump_bytes(
+			"",
+			DUMP_PREFIX_NONE,
+			cas_ctl->tx_buf,
+			CA8210_SPI_BUF_SIZE
+	);
+	dev_dbg(&priv->spi->dev, "spi transfer in: \n");
+	print_hex_dump_bytes(
+			"",
+			DUMP_PREFIX_NONE,
+			cas_ctl->tx_in_buf,
+			CA8210_SPI_BUF_SIZE
+	);
+
 	if (
 		(cas_ctl->tx_in_buf[0] == SPI_NACK ||
 		cas_ctl->tx_in_buf[0] == SPI_IDLE) &&
@@ -926,21 +942,6 @@ static void ca8210_spi_transfer_complete(void *context)
 		) {
 		duplex_rx = true;
 	}
-
-	dev_dbg(&priv->spi->dev, "spi transfer out: \n");
-	print_hex_dump_bytes(
-			"",
-			DUMP_PREFIX_NONE,
-			cas_ctl->tx_buf,
-			CA8210_SPI_BUF_SIZE
-	);
-	dev_dbg(&priv->spi->dev, "spi transfer in: \n");
-	print_hex_dump_bytes(
-			"",
-			DUMP_PREFIX_NONE,
-			cas_ctl->tx_in_buf,
-			CA8210_SPI_BUF_SIZE
-	);
 
 	if (duplex_rx) {
 		dev_dbg(&priv->spi->dev, "READ CMD DURING TX\n");

--- a/Module/ca8210.c
+++ b/Module/ca8210.c
@@ -920,7 +920,7 @@ static void ca8210_spi_transfer_complete(void *context)
 		memcpy(retry_work->tx_buf, cas_ctl->tx_buf, CA8210_SPI_BUF_SIZE);
 		kfree(cas_ctl);
 		priv->retries++;
-		queue_delayed_work(priv->irq_workqueue, &retry_work->work, msecs_to_jiffies(1));
+		queue_work(priv->irq_workqueue, &retry_work->work);
 		dev_info(&priv->spi->dev, "queued spi write retry\n");
 		return;
 	} else if (

--- a/Module/ca8210.c
+++ b/Module/ca8210.c
@@ -644,7 +644,6 @@ static int ca8210_test_int_driver_write(
 	struct ca8210_priv *priv = spi_get_drvdata(spi);
 	struct ca8210_test *test = &priv->test;
 	u8 *fifo_buffer;
-	int i;
 
 	dev_dbg(
 		&priv->spi->dev,
@@ -888,7 +887,6 @@ static void ca8210_spi_transfer_complete(void *context)
 	struct ca8210_priv *priv = cas_ctl->priv;
 	struct work_data_container *retry_work;
 	bool duplex_rx = false;
-	int i;
 
 	if (
 		(cas_ctl->tx_in_buf[0] == SPI_NACK ||
@@ -967,7 +965,7 @@ static int ca8210_spi_transfer(
 	size_t              len
 )
 {
-	int i, status = 0;
+	int status = 0;
 	struct ca8210_priv *priv = spi_get_drvdata(spi);
 	struct cas_control *cas_ctl;
 

--- a/Module/ca8210.c
+++ b/Module/ca8210.c
@@ -397,7 +397,7 @@ struct work_priv_container {
  *
  */
 struct work_data_container {
-	struct work_struct work;
+	struct delayed_work work;
 	struct ca8210_priv *priv;
 	u8 tx_buf[CA8210_SPI_BUF_SIZE];
 };
@@ -907,7 +907,7 @@ static void ca8210_spi_transfer_complete(void *context)
 
 		retry_work = kmalloc(sizeof(*retry_work), GFP_ATOMIC);
 		retry_work->priv = priv;
-		INIT_WORK(
+		INIT_DELAYED_WORK(
 			&retry_work->work,
 			ca8210_spi_transfer_retry_worker
 		);

--- a/Module/ca8210.c
+++ b/Module/ca8210.c
@@ -899,6 +899,8 @@ static int ca8210_spi_transfer_complete(void *context)
 		ca8210_rx_done(cas_ctl);	//This involves sleeping - not in this context! -> Use a workqueue
 	}
 	priv->retries = 0;
+
+	return 0;
 }
 
 /**

--- a/Module/ca8210.c
+++ b/Module/ca8210.c
@@ -896,7 +896,7 @@ static int ca8210_spi_transfer_complete(void *context)
 
 	if (duplex_rx) {
 		dev_dbg(&priv->spi->dev, "READ CMD DURING TX\n");
-		ca8210_rx_done(cas_ctl);	//This involves sleeping - not in this context! -> Use a workqueue
+		ca8210_rx_done(cas_ctl);
 	}
 	priv->retries = 0;
 
@@ -2660,11 +2660,6 @@ static unsigned int ca8210_test_int_poll(
 	poll_wait(filp, &priv->test.readq, ptable);
 	if (!kfifo_is_empty(&priv->test.up_fifo))
 		return_flags |= (POLLIN | POLLRDNORM);
-	if (wait_event_interruptible(
-		priv->test.readq,
-		!kfifo_is_empty(&priv->test.up_fifo))) {
-		return POLLERR;
-	}
 	return return_flags;
 }
 

--- a/Module/ca8210.c
+++ b/Module/ca8210.c
@@ -853,7 +853,7 @@ static int ca8210_remove(struct spi_device *spi_device);
 
 /**
  * ca8210_spi_transfer_complete() - Called when a single spi transfer has
- *                                  completed (Context which cannot sleep)
+ *                                  completed
  * @context:  Pointer to the cas_control object for the finished transfer
  */
 static int ca8210_spi_transfer_complete(void *context)

--- a/Module/ca8210.c
+++ b/Module/ca8210.c
@@ -887,8 +887,9 @@ static void ca8210_spi_transfer_complete(void *context)
 	struct ca8210_priv *priv = cas_ctl->priv;
 	struct work_data_container *retry_work;
 	bool duplex_rx = false;
+	int status = cas_ctl->msg.status;
 
-	dev_dbg(&priv->spi->dev, "spi transfer complete.\n");
+	dev_dbg(&priv->spi->dev, "spi transfer complete. status: %d\n", status);
 	dev_dbg(&priv->spi->dev, "spi transfer out: \n");
 	print_hex_dump_bytes(
 			"",


### PR DESCRIPTION
There were a few things going on in the IRQ routine which are not supposed to occur in a context which can't sleep. Moving to a workqueue instead fixes this, and under test does seem to improve stability, although futher testing is needed.

Furthermore, in a context which can sleep, controlling resource access is simpler, so should be able to provide better stability in future.

Any comments or suggestions?